### PR TITLE
Update site-rss-button.js

### DIFF
--- a/elements/haxcms-elements/lib/ui-components/site/site-rss-button.js
+++ b/elements/haxcms-elements/lib/ui-components/site/site-rss-button.js
@@ -37,6 +37,7 @@ class SiteRSSButton extends PolymerElement {
           background-color: var(--site-rss-bg-color, #383f45);
           font-size: var(--site-rss-font-size, 13px);
           margin: 0;
+          border-radius: var(--site-rss-border-radius, 3px);
         }
         paper-button:hover,
         paper-button:focus,


### PR DESCRIPTION
Added a border-radius variable to paper-button so we could further control style; the 3px default that I added is the standard border-radius that ships w/ paper-button outta-the-box.