### PR TITLE
Update site-rss-button.js

### DIFF
--- a/elements/haxcms-elements/lib/ui-components/site/site-rss-button.js
+++ b/elements/haxcms-elements/lib/ui-components/site/site-rss-button.js
@@ -51,7 +51,7 @@ class SiteRSSButton extends PolymerElement {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <paper-button raised>
+        <paper-button raised="[[raised]]">
           <iron-icon icon="[[icon]]"></iron-icon> [[label]]
         </paper-button>
       </a>
@@ -66,6 +66,11 @@ class SiteRSSButton extends PolymerElement {
         type: String,
         value: "rss",
         observer: "_generateLink"
+      },
+      raised: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
       }
     };
   }


### PR DESCRIPTION
Added 'raised' property for ability to toggle drop-shadow styling.  Probably not a convention we want to follow, but since it's just a button, having a 'raised' property makes sense.