### PR TITLE
preserve yarn cache between travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ install:
   - lerna exec -- yarn link
 script:
     - npm test -- --verbose
+cache: yarn


### PR DESCRIPTION
keeps dependencies that have previously been downloaded between test runs to avoid unneeded network calls to the package registry.