### PR TITLE
learn-two-theme: Previous / Next button adjustment

### DIFF
--- a/elements/learn-two-theme/learn-two-theme.js
+++ b/elements/learn-two-theme/learn-two-theme.js
@@ -249,7 +249,7 @@ class LearnTwoTheme extends HAXCMSTheme(PolymerElement) {
           max-height: calc(100vh - 160px);
         }
         app-drawer-layout[narrow] site-menu-button {
-          bottom: 0;
+          bottom: 60px;
           top: unset;
           --site-menu-button-button: {
             background-color: transparent !important;


### PR DESCRIPTION
Added bottom: 60px to app-drawer-layout[narrow] site-menu-button in learn-two-theme.  This allows the buttons to clear the HAX edit menu when in 'narrow' display.