### PR TITLE
Use symbolic link for Cygwin compatibility

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -9,26 +9,26 @@ for project in */ ; do
   cd ${project}
   p="$(basename -- $project)"
   rm -rf node_modules
-  ln -s ../../node_modules
+  symlink-dir ../../node_modules node_modules
   DIRECTORY="../../node_modules/@lrnwebcomponents/${p}"
   if [ -d "$DIRECTORY" ]; then
     rm ../../node_modules/@lrnwebcomponents/${p}
   fi
   mkdir ../../node_modules/@lrnwebcomponents/${p}
   if [ -f "${p}.js" ]; then
-    ln -s ../../../elements/${p}/${p}.js ../../node_modules/@lrnwebcomponents/${p}/${p}.js
+    symlink-dir ../../../elements/${p}/${p}.js ../../node_modules/@lrnwebcomponents/${p}/${p}.js
   fi
   if [ -d "lib" ]; then
-    ln -s ../../../elements/${p}/lib ../../node_modules/@lrnwebcomponents/${p}/lib
+    symlink-dir ../../../elements/${p}/lib ../../node_modules/@lrnwebcomponents/${p}/lib
   fi
   if [ -d "build" ]; then
-    ln -s ../../../elements/${p}/build ../../node_modules/@lrnwebcomponents/${p}/build
+    symlink-dir ../../../elements/${p}/build ../../node_modules/@lrnwebcomponents/${p}/build
   fi
   if [ -d "src" ]; then
-    ln -s ../../../elements/${p}/src ../../node_modules/@lrnwebcomponents/${p}/src
+    symlink-dir ../../../elements/${p}/src ../../node_modules/@lrnwebcomponents/${p}/src
   fi
   if [ -d "dist" ]; then
-    ln -s ../../../elements/${p}/dist ../../node_modules/@lrnwebcomponents/${p}/dist
+    symlink-dir ../../../elements/${p}/dist ../../node_modules/@lrnwebcomponents/${p}/dist
   fi
   cd ../
 done


### PR DESCRIPTION
Use symlink-dir instead of ln -s, and added identification to line 12