### PR TITLE
Fix state management issue with the HAX tray

### DIFF
--- a/elements/a11y-collapse/lib/a11y-collapse-group.js
+++ b/elements/a11y-collapse/lib/a11y-collapse-group.js
@@ -73,6 +73,13 @@ class A11yCollapseGroup extends LitElement {
       e.stopPropagation();
       e.stopImmediatePropagation();
     });
+    this.addEventListener("toggle", e => {
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      this.radioToggle(e.detail);
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    });
   }
   static get tag() {
     return "a11y-collapse-group";

--- a/elements/hax-body/lib/hax-tray.js
+++ b/elements/hax-body/lib/hax-tray.js
@@ -608,7 +608,7 @@ class HaxTray extends winEventsElement(LitElement) {
             ></hax-tray-button>
           </div>
         </div>
-        <a11y-collapse-group accordion>
+        <a11y-collapse-group accordion radio>
           <slot name="tray-collapse-pre"></slot>
           <a11y-collapse
             id="addcollapse"
@@ -726,6 +726,7 @@ class HaxTray extends winEventsElement(LitElement) {
         );
         break;
       case "insert-stax":
+        this.shadowRoot.querySelector("#settingscollapse").expand();
         this.dispatchEvent(
           new CustomEvent("hax-insert-content-array", {
             bubbles: true,
@@ -753,6 +754,7 @@ class HaxTray extends winEventsElement(LitElement) {
           },
           content: content
         };
+        this.shadowRoot.querySelector("#settingscollapse").expand();
         this.dispatchEvent(
           new CustomEvent("hax-insert-content", {
             bubbles: true,
@@ -780,6 +782,7 @@ class HaxTray extends winEventsElement(LitElement) {
           properties,
           innerContent
         );
+        this.shadowRoot.querySelector("#settingscollapse").expand();
         this.dispatchEvent(
           new CustomEvent("hax-insert-content", {
             bubbles: true,


### PR DESCRIPTION
- sets the a11y-collapse-group to radio mode and selects settings when content is added from tray.
- group listens for expand() method.