### PR TITLE
Unpublished navigation

### DIFF
--- a/elements/editable-outline/editable-outline.js
+++ b/elements/editable-outline/editable-outline.js
@@ -43,6 +43,7 @@ class EditableOutline extends LitElement {
             left: -9999px;
           }
         }
+
         button {
           height: 32px;
           font-size: 10px;
@@ -58,6 +59,7 @@ class EditableOutline extends LitElement {
         #outline {
           margin: 0;
         }
+
         ul {
           font-size: 16px;
           line-height: 32px;
@@ -68,37 +70,45 @@ class EditableOutline extends LitElement {
           height: auto;
           transition: 0.2s ease-in-out all;
         }
+
         li {
           font-size: 16px;
           line-height: 32px;
           padding: 4px;
           transition: 0.2s linear all;
         }
+
         ul:hover {
           outline: 1px solid #eeeeee;
         }
+
         li.collapsed-title {
           background-color: #dddddd;
         }
+
         li.collapsed-title:after {
           content: "    ( Double-click to expand )";
         }
+
         li:after {
           transition: 0.4s ease-in-out all;
           opacity: 0;
           font-size: 11px;
           visibility: hidden;
         }
+
         li.collapsed-title:hover:after {
           font-style: italic;
           opacity: 1;
           visibility: visible;
         }
+
         ul.collapsed-content {
           visibility: hidden;
           opacity: 0;
           height: 0;
         }
+
         li:focus,
         li:active,
         li:hover {
@@ -109,9 +119,14 @@ class EditableOutline extends LitElement {
         iron-icon {
           pointer-events: none;
         }
+
+        li[data-jos-published="false"] {
+          text-decoration: line-through;
+        }
       `
     ];
   }
+
   // render function
   render() {
     return html`

--- a/elements/editable-outline/src/editable-outline.css
+++ b/elements/editable-outline/src/editable-outline.css
@@ -24,6 +24,7 @@
     left: -9999px;
   }
 }
+
 button {
   height: 32px;
   font-size: 10px;
@@ -39,6 +40,7 @@ button span {
 #outline {
   margin: 0;
 }
+
 ul {
   font-size: 16px;
   line-height: 32px;
@@ -49,37 +51,45 @@ ul {
   height: auto;
   transition: .2s ease-in-out all;
 }
+
 li {
   font-size: 16px;
   line-height: 32px;
   padding: 4px;
   transition: .2s linear all;
 }
+
 ul:hover {
   outline: 1px solid #EEEEEE;
 }
+
 li.collapsed-title {
   background-color: #dddddd;
 }
+
 li.collapsed-title:after {
-  content:"    ( Double-click to expand )";
+  content: "    ( Double-click to expand )";
 }
+
 li:after {
   transition: .4s ease-in-out all;
   opacity: 0;
   font-size: 11px;
   visibility: hidden;
 }
+
 li.collapsed-title:hover:after {
   font-style: italic;
   opacity: 1;
   visibility: visible;
 }
+
 ul.collapsed-content {
   visibility: hidden;
   opacity: 0;
   height: 0;
 }
+
 li:focus,
 li:active,
 li:hover {
@@ -89,4 +99,8 @@ li:hover {
 
 iron-icon {
   pointer-events: none;
+}
+
+li[data-jos-published="false"] {
+  text-decoration: line-through;
 }

--- a/elements/haxcms-elements/lib/core/haxcms-site-store.js
+++ b/elements/haxcms-elements/lib/core/haxcms-site-store.js
@@ -218,8 +218,7 @@ class Store {
        * item.
        */
       if (
-        varGet(manifest, "metadata.site.settings.publishPagesOn", false) ===
-        true
+        varGet(manifest, "metadata.site.settings.publishPagesOn", true) === true
       ) {
         const filterHiddenParentsRecursive = item => {
           // if the item is unpublished then remove it.

--- a/elements/haxcms-elements/lib/core/haxcms-site-store.js
+++ b/elements/haxcms-elements/lib/core/haxcms-site-store.js
@@ -183,31 +183,6 @@ class Store {
       })
     );
     if (manifest && typeof manifest.items !== "undefined") {
-      let userData = JSON.parse(
-        window.localStorage.getItem("HAXCMSSystemData")
-      );
-      var accessData = {};
-      // establish on first pass if needed
-      if (userData == null) {
-        userData = {
-          manifests: {}
-        };
-        userData.manifests[manifest.id] = {
-          accessData: {}
-        };
-        window.localStorage.setItem(
-          "HAXCMSSystemData",
-          JSON.stringify(userData)
-        );
-      }
-      if (
-        userData &&
-        typeof userData.manifests !== typeof undefined &&
-        typeof userData.manifests[manifest.id] !== typeof undefined &&
-        userData.manifests[manifest.id].accessData !== typeof undefined
-      ) {
-        accessData = userData.manifests[manifest.id].accessData;
-      }
       let manifestItems = manifest.items.map(i => {
         let parentLocation = null;
         let parentSlug = null;
@@ -216,11 +191,7 @@ class Store {
           parentLocation = parent.location;
           parentSlug = parent.slug;
         }
-        // get local storage and look for data from this to mesh up
         let metadata = i.metadata;
-        if (typeof accessData[i.id] !== typeof undefined) {
-          metadata.accessData = accessData[i.id];
-        }
         let location = i.location;
         let slug = i.slug;
         return Object.assign({}, i, {
@@ -263,14 +234,16 @@ class Store {
           // if it got this far then it should be good.
           return true;
         };
-        manifestItems = manifestItems.filter(i =>
-          filterHiddenParentsRecursive(i)
-        );
+        // If the user is not logged in then we need to hide unpublished nodes items
+        if (!this.isLoggedIn) {
+          manifestItems = manifestItems.filter(i =>
+            filterHiddenParentsRecursive(i)
+          );
+        }
       }
 
       return Object.assign({}, manifest, {
-        items: manifestItems,
-        accessData: accessData
+        items: manifestItems
       });
     }
   }

--- a/elements/json-outline-schema/json-outline-schema.js
+++ b/elements/json-outline-schema/json-outline-schema.js
@@ -541,6 +541,11 @@ class JsonOutlineSchema extends HTMLElement {
       if (tree[i].slug) {
         li.setAttribute("data-jos-slug", tree[i].slug);
       }
+      if (typeof tree[i].metadata !== "undefined") {
+        if (typeof tree[i].metadata.published !== "undefined") {
+          li.setAttribute("data-jos-published", tree[i].metadata.published);
+        }
+      }
       appendTarget.appendChild(li);
       if (tree[i].children && tree[i].children.length > 0) {
         appendTarget.appendChild(

--- a/elements/json-outline-schema/src/json-outline-schema.js
+++ b/elements/json-outline-schema/src/json-outline-schema.js
@@ -541,6 +541,11 @@ class JsonOutlineSchema extends HTMLElement {
       if (tree[i].slug) {
         li.setAttribute("data-jos-slug", tree[i].slug);
       }
+      if (typeof tree[i].metadata !== "undefined") {
+        if (typeof tree[i].metadata.published !== "undefined") {
+          li.setAttribute("data-jos-published", tree[i].metadata.published);
+        }
+      }
       appendTarget.appendChild(li);
       if (tree[i].children && tree[i].children.length > 0) {
         appendTarget.appendChild(

--- a/elements/map-menu/lib/map-menu-builder.js
+++ b/elements/map-menu/lib/map-menu-builder.js
@@ -42,6 +42,7 @@ class MapMenuBuilder extends LitElement {
                         ? item.metadata.avatarLabel
                         : ""}"
                       selected="${this.selected}"
+                      .published="${item.metadata.published}"
                     >
                       <map-menu-builder
                         .items="${item.children}"
@@ -64,6 +65,7 @@ class MapMenuBuilder extends LitElement {
                         : ""}"
                       active-path="${this.activePath}"
                       selected="${this.selected}"
+                      .published="${item.metadata.published}"
                     ></map-menu-item>
                   `}
             `

--- a/elements/map-menu/lib/map-menu-item.js
+++ b/elements/map-menu/lib/map-menu-item.js
@@ -107,6 +107,7 @@ class MapMenuItem extends LitElement {
     this.title = "";
     this.url = "";
     this.active = false;
+    this.published = true;
   }
   /**
    * LitElement life cycle - properties definition
@@ -138,6 +139,9 @@ class MapMenuItem extends LitElement {
       },
       selected: {
         type: String
+      },
+      published: {
+        type: Boolean
       }
     };
   }
@@ -151,6 +155,11 @@ class MapMenuItem extends LitElement {
       }
       if (["id", "selected"].includes(propName)) {
         this.__selectedChanged(this.selected, this.id);
+      }
+      if (propName == "published") {
+        if (this.published === false) {
+          this.icon = "visibility-off";
+        }
       }
     });
   }

--- a/elements/map-menu/lib/map-menu-submenu.js
+++ b/elements/map-menu/lib/map-menu-submenu.js
@@ -29,6 +29,7 @@ class MapMenuSubmenu extends LitElement {
     this.expandChildren = false;
     this.avatarLabel = "";
     this.label = "";
+    this.published = true;
     import("@lrnwebcomponents/map-menu/lib/map-menu-header.js");
     import("@polymer/iron-collapse/iron-collapse.js");
     setTimeout(() => {
@@ -57,7 +58,6 @@ class MapMenuSubmenu extends LitElement {
         ?opened="${this.opened}"
         url="${this.url}"
         icon="${this.icon}"
-        selected="${this.selected}"
       ></map-menu-header>
       <iron-collapse id="container"> <slot></slot> </iron-collapse>
     `;
@@ -102,6 +102,9 @@ class MapMenuSubmenu extends LitElement {
       },
       selected: {
         type: String
+      },
+      published: {
+        type: Boolean
       }
     };
   }
@@ -112,6 +115,11 @@ class MapMenuSubmenu extends LitElement {
     changedProperties.forEach((oldValue, propName) => {
       if (propName == "opened") {
         this._openedChanged(this[propName], oldValue);
+      }
+      if (propName == "published") {
+        if (this.published === false) {
+          this.icon = "visibility-off";
+        }
       }
     });
   }


### PR DESCRIPTION
I added a check for authenticated users that will show them unpublished pages.  There is a "visibility-off" icon next to the map-menu item.  I also added an attribute in json-outline-schema to indicate if it's published.

## Example

In this example, the logged in user can see that "Week 3" is unpublished.  And non-logged in users don't see "Week 3"

![Screen Shot 2020-08-17 at 2 30 38 PM](https://user-images.githubusercontent.com/3428964/90431007-5ee4f180-e096-11ea-883e-2f7d2614d28b.png)

![Screen Shot 2020-08-17 at 2 32 07 PM](https://user-images.githubusercontent.com/3428964/90431059-758b4880-e096-11ea-93cc-408f7b969c67.png)

![Screen Shot 2020-08-17 at 3 01 41 PM](https://user-images.githubusercontent.com/3428964/90433935-a2d9f580-e09a-11ea-8a82-a22644779b94.png)

