### PR TITLE
Lrn math fixes

### DIFF
--- a/elements/lrn-math/lrn-math.js
+++ b/elements/lrn-math/lrn-math.js
@@ -188,6 +188,30 @@ class LrnMath extends HTMLElement {
     });
   }
 
+  /**
+   * Use Math-Text as a method for transfering values
+   * from hax inline text to the slot.
+   */
+  static get observedAttributes() {
+    return ["math-text"];
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    switch (name) {
+      case "math-text":
+        if (newValue !== "" && newValue !== null) {
+          // If a value has been set then wrap it in a
+          // span tag and inject it into the lightdom
+          const container = document.createElement("span");
+          container.innerText = newValue;
+          this.innerHTML = "";
+          this.appendChild(container);
+          this.removeAttribute("math-text");
+        }
+        break;
+    }
+  }
+
   static get haxProperties() {
     return {
       canScale: true,

--- a/elements/lrn-math/lrn-math.js
+++ b/elements/lrn-math/lrn-math.js
@@ -158,6 +158,24 @@ function update(elem) {
   }
 }
 
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// `wait` milliseconds.
+// https://levelup.gitconnected.com/debounce-in-javascript-improve-your-applications-performance-5b01855e086
+const debounce = (func, wait) => {
+  let timeout;
+
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+};
+
 /**
  * lrn-math
  * A mathjax wrapper tag in vanillaJS
@@ -179,9 +197,11 @@ class LrnMath extends HTMLElement {
     window.requestAnimationFrame(function() {
       elem._private = {
         check: "",
-        observer: new MutationObserver(function() {
-          update(elem);
-        })
+        observer: new MutationObserver(
+          debounce(function() {
+            update(elem);
+          }, 300)
+        )
       };
       update(elem);
       elem._private.observer.observe(elem, mutation_config);

--- a/elements/lrn-math/package.json
+++ b/elements/lrn-math/package.json
@@ -8,12 +8,7 @@
     "useHAX": true,
     "useSass": false,
     "files": {
-      "css": "src/lrn-math.css",
-      "scss": "src/lrn-math.scss",
-      "html": "src/lrn-math.html",
-      "js": "src/lrn-math.js",
-      "properties": "src/lrn-math-properties.json",
-      "hax": "src/lrn-math-hax.json"
+      "js": "src/lrn-math.js"
     },
     "sharedStyles": []
   },

--- a/elements/lrn-math/src/lrn-math.js
+++ b/elements/lrn-math/src/lrn-math.js
@@ -188,6 +188,30 @@ class LrnMath extends HTMLElement {
     });
   }
 
+  /**
+   * Use Math-Text as a method for transfering values
+   * from hax inline text to the slot.
+   */
+  static get observedAttributes() {
+    return ["math-text"];
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    switch (name) {
+      case "math-text":
+        if (newValue !== "" && newValue !== null) {
+          // If a value has been set then wrap it in a
+          // span tag and inject it into the lightdom
+          const container = document.createElement("span");
+          container.innerText = newValue;
+          this.innerHTML = "";
+          this.appendChild(container);
+          this.removeAttribute("math-text");
+        }
+        break;
+    }
+  }
+
   static get haxProperties() {
     return {
       canScale: true,

--- a/elements/lrn-math/src/lrn-math.js
+++ b/elements/lrn-math/src/lrn-math.js
@@ -158,6 +158,24 @@ function update(elem) {
   }
 }
 
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// `wait` milliseconds.
+// https://levelup.gitconnected.com/debounce-in-javascript-improve-your-applications-performance-5b01855e086
+const debounce = (func, wait) => {
+  let timeout;
+
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+};
+
 /**
  * lrn-math
  * A mathjax wrapper tag in vanillaJS
@@ -179,9 +197,11 @@ class LrnMath extends HTMLElement {
     window.requestAnimationFrame(function() {
       elem._private = {
         check: "",
-        observer: new MutationObserver(function() {
-          update(elem);
-        })
+        observer: new MutationObserver(
+          debounce(function() {
+            update(elem);
+          }, 300)
+        )
       };
       update(elem);
       elem._private.observer.observe(elem, mutation_config);


### PR DESCRIPTION
Fixes converting inline text to lrn-math tag using HAX.  Treats math-text attribute as a proxy for the slotted content.

Fixes https://github.com/elmsln/HAXcms/issues/396 I believe.  I added a debounce to the update function.  This fixes the issue of the user typing quickly and inadvertently creating multiple instances of the current input.

There is an issue with running polyemer build on my local machine so there have been no AMD files generated.  That still needs done.