### PR TITLE
build: transform dynamic imports to static imports for umd build

### DIFF
--- a/scripts/babel-plugin-dynamic-to-static-import.js
+++ b/scripts/babel-plugin-dynamic-to-static-import.js
@@ -1,0 +1,27 @@
+export default function(babel) {
+  const { types: t } = babel;
+
+  return {
+    visitor: {
+      ExpressionStatement(path) {
+        // find dynamic import expression
+        if (
+          t.isCallExpression(path.node.expression) &&
+          t.isImport(path.node.expression.callee)
+        ) {
+          // create static import
+          const staticImport = t.importDeclaration(
+            [],
+            t.stringLiteral(path.node.expression.arguments[0].value)
+          );
+          // prepend to program
+          path
+            .findParent(path => path.isProgram())
+            .node.body.unshift(staticImport);
+          // remove dynamic import
+          path.remove();
+        }
+      }
+    }
+  };
+}

--- a/scripts/babel-plugin-dynamic-to-static-import.js
+++ b/scripts/babel-plugin-dynamic-to-static-import.js
@@ -1,10 +1,12 @@
+let counter = 0;
+
 export default function(babel) {
   const { types: t } = babel;
 
   return {
     visitor: {
       ExpressionStatement(path) {
-        // find dynamic import expression
+        // handle `import("module-name")`
         if (
           t.isCallExpression(path.node.expression) &&
           t.isImport(path.node.expression.callee)
@@ -20,6 +22,61 @@ export default function(babel) {
             .node.body.unshift(staticImport);
           // remove dynamic import
           path.remove();
+          return;
+        }
+
+        // handle `await import("module-name")`
+        if (
+          t.isAwaitExpression(path.node.expression) &&
+          t.isCallExpression(path.node.expression.argument) &&
+          t.isImport(path.node.expression.argument.callee)
+        ) {
+          // create static import
+          const staticImport = t.importDeclaration(
+            [],
+            t.stringLiteral(path.node.expression.argument.arguments[0].value)
+          );
+          // prepend to program
+          path
+            .findParent(path => path.isProgram())
+            .node.body.unshift(staticImport);
+          // remove dynamic import
+          path.remove();
+        }
+      },
+      MemberExpression(path) {
+        // handle `import("module-name").then()`
+        if (
+          t.isCallExpression(path.node.object) &&
+          t.isImport(path.node.object.callee)
+        ) {
+          const importIdentifier = `\$\$${counter}`;
+
+          // create static import
+          const staticImport = t.importDeclaration(
+            [t.importNamespaceSpecifier(t.identifier(importIdentifier))],
+            t.stringLiteral(path.node.object.arguments[0].value)
+          );
+          // prepend to program
+          path
+            .findParent(path => path.isProgram())
+            .node.body.unshift(staticImport);
+          // replace `import("module-name").then`
+          // with `Promise.resolve($$moduleId).then
+          path.replaceWith(
+            t.memberExpression(
+              t.callExpression(
+                t.memberExpression(
+                  t.identifier("Promise"),
+                  t.identifier("resolve")
+                ),
+                [t.identifier(importIdentifier)]
+              ),
+              t.identifier("then")
+            )
+          );
+          counter++;
+          return;
         }
       }
     }

--- a/scripts/rollup.config.factory.js
+++ b/scripts/rollup.config.factory.js
@@ -1,4 +1,5 @@
 import babel from "rollup-plugin-babel";
+import babelPluginDynamicToStaticImport from "./babel-plugin-dynamic-to-static-import";
 import commonjs from "@rollup/plugin-commonjs";
 import { terser } from "rollup-plugin-terser";
 import del from "rollup-plugin-delete";
@@ -18,7 +19,8 @@ function umdConfig({ elementName, className } = {}) {
         presets: ["@babel/preset-env"],
         plugins: [
           "@babel/plugin-syntax-dynamic-import",
-          "@babel/plugin-syntax-import-meta"
+          "@babel/plugin-syntax-import-meta",
+          babelPluginDynamicToStaticImport
         ]
       }),
       terser(),


### PR DESCRIPTION
rollup currently does not support dynamic import in iife or umd builds.
this transforms dynamic imports to static imports to allow umd builds to continue to work.

an example of the input and output of the plugin can be seen here https://astexplorer.net/#/gist/16c8cd275ea5b0df3da862d2fb5add9a/8ce0535267e300bc149d78a9b738b5740df63a8b