### PR TITLE
chore: upgrade node sass to version 4.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "lodash": "4.17.19",
         "lodash.clonedeep": "4.5.0",
         "lorem-ipsum": "^2.0.3",
-        "node-sass": "4.13.1",
+        "node-sass": "4.14.1",
         "polymer-build": "3.1.4",
         "polymer-cli": "1.9.11",
         "polymer-webpack-loader": "2.0.3",


### PR DESCRIPTION
version 4.14.0 adds support for node 14.
https://github.com/sass/node-sass/releases/tag/v4.14.0

which should resolve ci/build issues on node 14, like:
https://github.com/elmsln/lrnwebcomponents/runs/1107048076