### PR TITLE
ci(github-actions): add macos to matrix, drop test script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,15 @@ jobs:
   build-and-test:
     name: "${{ matrix.platform }}: node.js ${{ matrix.node-version }}"
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10, 12, 14]
-      fail-fast: false
+        node-version: [14]
+        include:
+          - platform: ubuntu-latest
+            node-version: 12
+          - platform: ubuntu-latest
+            node-version: 10
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     name: "${{ matrix.platform }}: node.js ${{ matrix.node-version }}"
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10, 12, 14]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -35,5 +35,3 @@ jobs:
         run: yarn install
       - name: Build
         run: yarn lerna run build
-      - name: Test
-        run: yarn test --verbose

--- a/elements/a11y-figure/package.json
+++ b/elements/a11y-figure/package.json
@@ -46,7 +46,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.2",
-    "polymer-cli": "1.9.7",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.1"
   },

--- a/elements/air-horn/package.json
+++ b/elements/air-horn/package.json
@@ -49,7 +49,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/elmsln-studio/package.json
+++ b/elements/elmsln-studio/package.json
@@ -59,7 +59,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.2",
-    "polymer-cli": "1.9.7",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.1"
   },

--- a/elements/exif-data/package.json
+++ b/elements/exif-data/package.json
@@ -51,7 +51,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/figure-label/package.json
+++ b/elements/figure-label/package.json
@@ -51,7 +51,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.8.1",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2"
   },
   "private": false,

--- a/elements/git-corner/package.json
+++ b/elements/git-corner/package.json
@@ -52,7 +52,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/glossary-term/package.json
+++ b/elements/glossary-term/package.json
@@ -53,7 +53,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.8.1",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2"
   },
   "private": false,

--- a/elements/h5p-element/package.json
+++ b/elements/h5p-element/package.json
@@ -54,7 +54,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/hax-logo/package.json
+++ b/elements/hax-logo/package.json
@@ -44,7 +44,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/iframe-loader/package.json
+++ b/elements/iframe-loader/package.json
@@ -45,7 +45,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.0",
-    "polymer-cli": "1.8.1",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2"
   },
   "private": false,

--- a/elements/lazy-import-discover/package.json
+++ b/elements/lazy-import-discover/package.json
@@ -49,7 +49,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/lrndesign-gallery/package.json
+++ b/elements/lrndesign-gallery/package.json
@@ -60,7 +60,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.2",
-    "polymer-cli": "1.9.7",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.1"
   },

--- a/elements/lrndesign-timeline/package.json
+++ b/elements/lrndesign-timeline/package.json
@@ -59,7 +59,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.2",
-    "polymer-cli": "1.9.7",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.1"
   },

--- a/elements/nav-card/package.json
+++ b/elements/nav-card/package.json
@@ -55,7 +55,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.2",
-    "polymer-cli": "1.9.7",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.1"
   },

--- a/elements/portal-launcher/package.json
+++ b/elements/portal-launcher/package.json
@@ -49,7 +49,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/punnett-square/package.json
+++ b/elements/punnett-square/package.json
@@ -52,7 +52,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.8.1",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2"
   },
   "private": false,

--- a/elements/r-coder/package.json
+++ b/elements/r-coder/package.json
@@ -53,7 +53,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.8.1",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2"
   },
   "private": false,

--- a/elements/random-item/package.json
+++ b/elements/random-item/package.json
@@ -49,7 +49,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/rss-items/package.json
+++ b/elements/rss-items/package.json
@@ -57,7 +57,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/they-live/package.json
+++ b/elements/they-live/package.json
@@ -52,7 +52,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/elements/undo-manager/package.json
+++ b/elements/undo-manager/package.json
@@ -52,7 +52,7 @@
     "gulp-babel": "8.0.0",
     "lodash": "4.17.19",
     "polymer-build": "3.1.4",
-    "polymer-cli": "1.9.4",
+    "polymer-cli": "1.9.11",
     "wct-browser-legacy": "1.0.2",
     "web-animations-js": "2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -130,6 +130,9 @@
         "promise-polyfill": "8.1.3",
         "rollup-plugin-cpy": "^2.0.1"
     },
+    "resolutions": {
+      "chokidar": "^3.0.0"
+    },
     "lint-staged": {
         "*.{js,json}": "prettier --write",
         "*.{png,jpeg,jpg,gif,svg}": "imagemin-lint-staged",


### PR DESCRIPTION
tests are currently broken, running the tests adds 4 hours to each job in the matrix, removing it for now.

New test matrix

| operating system | node 14 | node 12 | node 10 |
| - | - | - | - |
| linux | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: |
| macos | :heavy_check_mark: | :no_entry: | :no_entry:  |
| windows | :heavy_check_mark: | :no_entry: | :no_entry:  |

this ensures that all versions of node and all OS'es are tested, but reduces the number of jobs from 9 to 5.
([github actions limits free projects to running 20 concurrent jobs at a time, and 5 macos jobs at a time](https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits))