### PR TITLE
Update self-check.js

### DIFF
--- a/elements/self-check/self-check.js
+++ b/elements/self-check/self-check.js
@@ -114,7 +114,7 @@ class SelfCheck extends lazyImageLoader(SchemaBehaviors(SimpleColors)) {
             --self-check-heading-color,
             var(--simple-colors-default-theme-accent-8, #444)
           );
-          display: inline-flex;
+          display: flex;
           width: 100%;
           margin: -20px 0 0;
         }

--- a/elements/self-check/self-check.js
+++ b/elements/self-check/self-check.js
@@ -115,6 +115,7 @@ class SelfCheck extends lazyImageLoader(SchemaBehaviors(SimpleColors)) {
             var(--simple-colors-default-theme-accent-8, #444)
           );
           display: flex;
+          align-items: center;
           width: 100%;
           margin: -20px 0 0;
         }


### PR DESCRIPTION
Adjusted #header-wrap display from inline-flex to flex; this fixes the weird spacing between the triangle and the header bar.