### PR TITLE
Fix simple-icon package.json placement

### DIFF
--- a/elements/lrnapp-fab-menu/package.json
+++ b/elements/lrnapp-fab-menu/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@lrnwebcomponents/materializecss-styles": "^2.8.0",
     "@lrnwebcomponents/paper-fab-speed-dial": "^2.8.0",
+    "@lrnwebcomponents/simple-icon": "^2.8.0",
     "@polymer/iron-flex-layout": "^3.0.1",
     "@polymer/paper-fab": "^3.0.1",
     "@polymer/polymer": "^3.3.1"
@@ -50,7 +51,6 @@
   "devDependencies": {
     "@lrnwebcomponents/deduping-fix": "^2.7.7",
     "@lrnwebcomponents/hax-iconset": "^2.8.0",
-    "@lrnwebcomponents/simple-icon": "^2.8.0",
     "@lrnwebcomponents/storybook-utilities": "^2.8.0",
     "@polymer/iron-component-page": "github:PolymerElements/iron-component-page",
     "@polymer/iron-demo-helpers": "3.1.0",


### PR DESCRIPTION
I'm using `@lrnwebcomponents/lrnapp-fab-menu` in my project, and when I build it with rollup, it shows the following warning:

```
(!) Unresolved dependencies
@lrnwebcomponents/simple-icon/simple-icon.js (imported by node_modules/@lrnwebcomponents/lrnapp-fab-menu/lrnapp-fab-menu.js, node_modules/@lrnwebcomponents/lrnapp-fab-menu/lib/lrnapp-fab-speed-dial-action.js)
@lrnwebcomponents/simple-icon/lib/simple-icon-button.js (imported by node_modules/@lrnwebcomponents/lrnapp-fab-menu/lrnapp-fab-menu.js, node_modules/@lrnwebcomponents/lrnapp-fab-menu/lib/lrnapp-fab-speed-dial-action.js)
@lrnwebcomponents/simple-icon/lib/simple-icons.js (imported by node_modules/@lrnwebcomponents/lrnapp-fab-menu/lrnapp-fab-menu.js, node_modules/@lrnwebcomponents/lrnapp-fab-menu/lib/lrnapp-fab-speed-dial-action.js)
```

The reason is simply because when I install my dependencies, `simple-icon` is not being included because it's listed as a devDependencies. This PR fix this.