### PR TITLE
Activity box updates

### DIFF
--- a/elements/course-design/lib/activity-box.js
+++ b/elements/course-design/lib/activity-box.js
@@ -74,11 +74,35 @@ class ActivityBox extends LitElement {
   static get tag() {
     return "activity-box";
   }
+  /**
+   * Implements haxHooks to tie into life-cycle if hax exists.
+   */
+  haxHooks() {
+    return {
+      activeElementChanged: "haxactiveElementChanged",
+    };
+  }
+  /**
+   * double-check that we are set to inactivate click handlers
+   * this is for when activated in a duplicate / adding new content state
+   */
+  haxactiveElementChanged(el, val) {
+    // flag for HAX to not trigger active on changes
+    let container = this.shadowRoot.querySelector(".tag");
+    if (val) {
+      container.setAttribute("contenteditable", true);
+    } else {
+      container.removeAttribute("contenteditable");
+      this.tag = container.innerText;
+    }
+    return false;
+  }
   static get haxProperties() {
     return {
       canScale: false,
       canPosition: false,
       canEditSource: true,
+      contentEditable: true,
       gizmo: {
         title: "Activity Box",
         description: "A small designed heading",

--- a/elements/course-design/lib/activity-box.js
+++ b/elements/course-design/lib/activity-box.js
@@ -17,6 +17,7 @@ class ActivityBox extends LitElement {
           padding-top: var(--activity-box-container-padding-top, 14px);
           margin-bottom: var(--activity-box-container-margin-bottom, 20px);
           position: relative;
+          min-height: 60px;
         }
         simple-icon {
           --simple-icon-height: 80px;
@@ -132,6 +133,14 @@ class ActivityBox extends LitElement {
             title: "No Colorize",
             description: "Check to stop any colors being applied to the icon",
             inputMethod: "boolean",
+          },
+          {
+            slot: "",
+            title: "Activity Box content:",
+            description:
+              "This is where you enter the content for the activity box.",
+            inputMethod: "code-editor",
+            required: true,
           },
         ],
         advanced: [],


### PR DESCRIPTION
Allowing tag & slotted content in `<activity-box>` to be editable on page and within the left-hand pane (in a code editor).
Added a fix to allow the activity box to be large enough to contain the simple-icon (when using a default icon).