### PR TITLE
Activity box fix

### DIFF
--- a/elements/course-design/lib/activity-box.js
+++ b/elements/course-design/lib/activity-box.js
@@ -194,14 +194,11 @@ class ActivityBox extends LitElement {
               ></simple-icon>
             `
           : html``}
-        ${this.tag
-          ? html`<div class="tag">
-              <span
-                ><simple-icon icon="check-circle"></simple-icon>${this
-                  .tag}</span
-              >
-            </div>`
-          : html``}
+        <div class="tag" ?hidden=${!this.tag}>
+          <span
+            ><simple-icon icon="check-circle"></simple-icon>${this.tag}</span
+          >
+        </div>
         <div class="pullout"><slot></slot></div>
       </div>
     `;


### PR DESCRIPTION
Fixed an issue which was causing HAX to become unresponsive when saving an activity box element with a non-empty tag.

HAX would be become unresponsive for several minutes when trying to save a page with an `activity-box` element which had a non-empty `tag`. It was throwing these errors in console:

![image](https://user-images.githubusercontent.com/2301874/107632507-7d4f3280-6c5e-11eb-8fcf-51eef28aeff4.png)

I think this was because the `tag` div was being removed from the DOM completely when empty which was causing HAX to fail when adding/removing the `contenteditable` attribute to it as part of the hook. I've instead switched it to adding a hidden property to the tag div so it's always in the DOM and it seems to be working properly now.

Sorry for the flurry of PRs with this element, think it's all finished for now!

PS. Having to submit it looking a little weird, I think the linter is preventing me from neatening up that code formatting so it looks a little off.