### PR TITLE
fixing typo and spacing for meme-maker

### DIFF
--- a/elements/meme-maker/demo/index.html
+++ b/elements/meme-maker/demo/index.html
@@ -14,48 +14,6 @@
   </head>
   <body>
     <div class="vertical-section-container centered">
-    <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
       <h3>Basic meme-maker demo</h3>
       <demo-snippet>
         <template>
@@ -67,32 +25,15 @@
             }
           </style>
           <meme-maker image-url="NGDLE-university.jpg"
-            top-text="You're university" bottom-text="stuck on edtech" style="width:75%;"></meme-maker>
+            top-text="Your university" bottom-text="stuck on edtech" style="width:75%;"></meme-maker>
         </template>
       </demo-snippet>
       <p>Spacing down the page</p>
       <p>Spacing down the page</p>
       <p>Spacing down the page</p>
       <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
-      <p>Spacing down the page</p>
       <meme-maker image-url="https://btopro.com/files/IMG_20190729_213158.jpg"
-            top-text="You're university" bottom-text="stuck on edtech" style="width:75%;"></meme-maker>
+            top-text="Your university" bottom-text="stuck on edtech" style="width:75%;"></meme-maker>
     </div>
   </body>
 </html>


### PR DESCRIPTION
I don't know why there was so much spacing needed for the demo, so maybe you want to keep it. I thought it was annoying so I deleted it. I also fixed the typo in the memes top-text from "You're" to "Your".