### PR TITLE
Update clean-two.js

### DIFF
--- a/elements/clean-two/src/clean-two.js
+++ b/elements/clean-two/src/clean-two.js
@@ -338,7 +338,7 @@ class CleanTwo extends HAXCMSRememberRoute(
           margin: 0px 16px;
           display: block;
           padding: 0;
-          width: 560px;
+          max-width: 600px;
         }
         @media screen and (max-width: 400px) {
           .content {


### PR DESCRIPTION
Currently the fixed width on .content is preventing mobile responsive resizing. I added a max-width to allow for flexibility / to fix mobile responsive issue while still maintaining the slim content styling.