### PR TITLE
Update learn-two-theme.js

### DIFF
--- a/elements/learn-two-theme/src/learn-two-theme.js
+++ b/elements/learn-two-theme/src/learn-two-theme.js
@@ -269,7 +269,7 @@ class LearnTwoTheme extends HAXCMSLitElementTheme {
           background-color: var(--learn-two-theme-menu-color, #383f45);
           color: #ffffff;
           padding: 0;
-          max-height: calc(100vh - 100px);
+          min-height: calc(100vh - 100px);
           --site-menu-active-color: #ffffff;
           --site-menu-item-active-item-color: goldenrod;
         }


### PR DESCRIPTION
Updated max-height on site-menu to be min-height; this fixes the issue w/ the sidebar not stretching the entire length of the page.

![Before](https://user-images.githubusercontent.com/11019355/130132274-5ac8eba4-4e41-4160-b6c2-bbcd2b3816fb.png)
![After](https://user-images.githubusercontent.com/11019355/130132287-2d345360-bcd1-47c5-8923-c5bbdd1faeaf.png)
