### PR TITLE
fixes fullscreen playback issue

### DIFF
--- a/elements/a11y-media-player/lib/a11y-media-state-manager.js
+++ b/elements/a11y-media-player/lib/a11y-media-state-manager.js
@@ -73,7 +73,8 @@ class A11yMediaStateManager extends LitElement {
   checkConcurrentPlayers() {
     let active = this.activePlayer;
     this.players.forEach((player) => {
-      if (player !== active) {
+      if (player.fullscreen) active = player;
+      if (!!active && player !== active) {
         player.toggleFullscreen(false);
         if (
           (!player.allowConcurrent && !active.allowConcurrent) ||
@@ -90,6 +91,7 @@ class A11yMediaStateManager extends LitElement {
    * @param {object} the player to set stickiness
    */
   setActivePlayer(player) {
+    console.log("active", this);
     this.activePlayer = player;
     this.checkConcurrentPlayers();
   }

--- a/elements/fullscreen-behaviors/fullscreen-behaviors.js
+++ b/elements/fullscreen-behaviors/fullscreen-behaviors.js
@@ -76,13 +76,16 @@ const FullscreenBehaviors = function (SuperClass) {
     get fullscreenEnabled() {
       return this.__fullscreenEnabled;
     }
-    _updateFullscreen(fullscreen = screenfull && screenfull.isFullscreen) {
+    _updateFullscreen(fullscreen) {
+      if (typeof fullscreen === typeof undefined)
+        fullscreen = screenfull && screenfull.isFullscreen;
       let delayedUpdate = (e) => {
         setTimeout(this._updateFullscreen(), 500);
       };
       this.__fullscreen = fullscreen;
+
+      //needed for escape key detection
       if (this.__fullscreen) {
-        console.log("liusten");
         document.addEventListener("fullscreenchange", delayedUpdate.bind(this));
       } else {
         document.removeEventListener(
@@ -99,7 +102,8 @@ const FullscreenBehaviors = function (SuperClass) {
       }
     }
 
-    toggleFullscreen(mode = !screenfull.isFullscreen) {
+    toggleFullscreen(mode) {
+      if (typeof mode === typeof undefined) mode = !screenfull.isFullscreen;
       if (this.fullscreenEnabled && screenfull) {
         if (mode) {
           screenfull.request(this.fullscreenTarget);


### PR DESCRIPTION
The a11-media-player manger didn't register player as active until video plays, so if video went to fullscreen before playing, the manager cancelled fullscreen. Now fullscreen mode also makes a player active.