### PR TITLE
Draft: Adding Watch on YouTube button

### DIFF
--- a/elements/a11y-media-player/a11y-media-player.js
+++ b/elements/a11y-media-player/a11y-media-player.js
@@ -1157,6 +1157,17 @@ class A11yMediaPlayer extends FullscreenBehaviors(SimpleColors) {
               label="${this._getLocal(this.localization, "settings", "label")}"
               @click="${(e) => this.toggleSettings()}"
             ></a11y-media-button>
+            ${this.isYoutube
+              ? html` <a11y-media-button
+                  accent-color="${this.accentColor}"
+                  ?dark="${this.dark}"
+                  class="hide-sticky"
+                  icon="av:play-arrow"
+                  label="Open on YouTube"
+                  ?hidden="${this.learningMode || this.hideYoutubeLink}"
+                  @click="${(e) => this.goToYoutube()}"
+                ></a11y-media-button>`
+              : ``}
           </div>
           <absolute-position-behavior
             id="settings"
@@ -1643,6 +1654,13 @@ class A11yMediaPlayer extends FullscreenBehaviors(SimpleColors) {
         type: Boolean,
       },
       /**
+       * Open on YouTube button
+       */
+      hideYoutubeLink: {
+        type: Boolean,
+        attribute: "hide-youtube-link",
+      },
+      /**
        * Playback rate where `1` is normal speed, `0.`5 is half-speed, and `2` is double speed
        */
       playbackRate: {
@@ -1841,6 +1859,7 @@ class A11yMediaPlayer extends FullscreenBehaviors(SimpleColors) {
     this.mediaTitle = "";
     this.mediaLang = "en";
     this.muted = false;
+    this.hideYoutubeLink = false;
     this.preload = "metadata";
     this.playbackRate = 1;
     this.search = null;
@@ -2679,6 +2698,13 @@ class A11yMediaPlayer extends FullscreenBehaviors(SimpleColors) {
         detail: this,
       })
     );
+  }
+
+  /**
+   * takes the user to YouTube
+   */
+  goToYoutube() {
+    window.open(`https://www.youtube.com/watch?v=${this.youtubeId}`);
   }
 
   /**

--- a/elements/a11y-media-player/src/a11y-media-player-properties.json
+++ b/elements/a11y-media-player/src/a11y-media-player-properties.json
@@ -201,6 +201,13 @@
     "type": "Boolean"
   },
   /**
+   * Open on YouTube button
+   */
+  "hideYoutubeLink": {
+    "type": "Boolean",
+    "attribute": "hide-youtube-link"
+  },
+  /**
    * Playback rate where `1` is normal speed, `0.`5 is half-speed, and `2` is double speed
    */
   "playbackRate": {

--- a/elements/a11y-media-player/src/a11y-media-player.html
+++ b/elements/a11y-media-player/src/a11y-media-player.html
@@ -182,6 +182,19 @@
         label="${this._getLocal(this.localization,'settings','label')}"
         @click="${e => this.toggleSettings()}"
       ></a11y-media-button>
+      ${this.isYoutube
+        ? html`
+        <a11y-media-button
+          accent-color="${this.accentColor}"
+          ?dark="${this.dark}"
+          class="hide-sticky"
+          icon="av:play-arrow"
+          label="Open on YouTube"
+          ?hidden="${this.learningMode || this.hideYoutubeLink}"
+          @click="${e => this.goToYoutube()}"
+        ></a11y-media-button>`
+        : ``
+      }
     </div>
     <absolute-position-behavior 
       id="settings" 

--- a/elements/a11y-media-player/src/a11y-media-player.js
+++ b/elements/a11y-media-player/src/a11y-media-player.js
@@ -138,6 +138,7 @@ class A11yMediaPlayer extends FullscreenBehaviors(SimpleColors) {
     this.mediaTitle = "";
     this.mediaLang = "en";
     this.muted = false;
+    this.hideYoutubeLink = false;
     this.preload = "metadata";
     this.playbackRate = 1;
     this.search = null;
@@ -976,6 +977,13 @@ class A11yMediaPlayer extends FullscreenBehaviors(SimpleColors) {
         detail: this,
       })
     );
+  }
+
+  /**
+   * takes the user to YouTube
+   */
+  goToYoutube() {
+    window.open(`https://www.youtube.com/watch?v=${this.youtubeId}`);
   }
 
   /**

--- a/elements/video-player/src/video-player-hax.json
+++ b/elements/video-player/src/video-player-hax.json
@@ -137,6 +137,12 @@
         "inputMethod": "boolean"
       },
       {
+        "property": "hideYoutubeLink",
+        "title": "Remove open on YouTube button",
+        "description": "Removes the button for opening the video on YouTube.",
+        "inputMethod": "boolean"
+      },
+      {
         "property": "preload",
         "title": "Preload source(s).",
         "description": "How the sources should be preloaded, i.e. auto, metadata (default), or none.",

--- a/elements/video-player/src/video-player-properties.json
+++ b/elements/video-player/src/video-player-properties.json
@@ -96,6 +96,13 @@
     "reflect": true
   },
   /**
+   * Open on YouTube button
+   */
+  "hideYoutubeLink": {
+    "type": "Boolean",
+    "attribute": "hide-youtube-link"
+  },
+  /**
    * What to preload for a11y-media-player: auto, metadata (default), or none.
    */
   "preload": {

--- a/elements/video-player/src/video-player.html
+++ b/elements/video-player/src/video-player.html
@@ -39,6 +39,7 @@ ${this.elementVisible ? html`${!this.isA11yMedia
         ?disable-interactive="${this.disableInteractive}"
         ?hide-timestamps="${this.hideTimestamps}"
         ?hide-transcript="${this.hideTranscript}"
+        ?hide-youtube-link="${this.hideYoutubeLink}"
         id="${this.playerId}"
         lang="${this.lang || 'en'}"
         ?learning-mode="${this.learningMode}"

--- a/elements/video-player/src/video-player.js
+++ b/elements/video-player/src/video-player.js
@@ -37,6 +37,7 @@ class VideoPlayer extends IntersectionObserverMixin(
     this.disableInteractive = false;
     this.hideTimestamps = false;
     this.hideTranscript = false;
+    this.hideYoutubeLink = false;
     this.lang = "en";
     this.learningMode = false;
     this.linkable = false;

--- a/elements/video-player/video-player.js
+++ b/elements/video-player/video-player.js
@@ -97,6 +97,7 @@ class VideoPlayer extends IntersectionObserverMixin(
               ?disable-interactive="${this.disableInteractive}"
               ?hide-timestamps="${this.hideTimestamps}"
               ?hide-transcript="${this.hideTranscript}"
+              ?hide-youtube-link="${this.hideYoutubeLink}"
               id="${this.playerId}"
               lang="${this.lang || "en"}"
               ?learning-mode="${this.learningMode}"
@@ -258,6 +259,12 @@ class VideoPlayer extends IntersectionObserverMixin(
             property: "linkable",
             title: "Include a share link?",
             description: "Provides a link to share the video.",
+            inputMethod: "boolean",
+          },
+          {
+            property: "hideYoutubeLink",
+            title: "Remove open on YouTube button",
+            description: "Removes the button for opening the video on YouTube.",
             inputMethod: "boolean",
           },
           {
@@ -500,6 +507,13 @@ class VideoPlayer extends IntersectionObserverMixin(
         reflect: true,
       },
       /**
+       * Open on YouTube button
+       */
+      hideYoutubeLink: {
+        type: Boolean,
+        attribute: "hide-youtube-link",
+      },
+      /**
        * What to preload for a11y-media-player: auto, metadata (default), or none.
        */
       preload: {
@@ -572,6 +586,7 @@ class VideoPlayer extends IntersectionObserverMixin(
     this.disableInteractive = false;
     this.hideTimestamps = false;
     this.hideTranscript = false;
+    this.hideYoutubeLink = false;
     this.lang = "en";
     this.learningMode = false;
     this.linkable = false;


### PR DESCRIPTION
https://github.com/elmsln/issues/issues/145

Need help getting a YouTube button svg for the media player that fits the 24 x 24 specification. This PR currently uses the av:play-arrow icon in place of a YouTube button. The button opens the YouTube page in a new window, hides when it is not a YouTube video, and is disabled with learning mode. 