### PR TITLE
RTL tooltip fix

### DIFF
--- a/elements/simple-tooltip/src/simple-tooltip.js
+++ b/elements/simple-tooltip/src/simple-tooltip.js
@@ -195,6 +195,8 @@ class SimpleTooltip extends LitElement {
         .hidden {
           position: absolute;
           left: -10000px;
+          inset-inline-start: -10000px;
+          inset-inline-end: initial;
           top: auto;
           width: 1px;
           height: 1px;


### PR DESCRIPTION
Fixed simple-tooltip RTL problem.
This is a non-breaking change adding inset-inline properties that will properly override the left property when needed. Tested in both LTR and RTL.